### PR TITLE
Deploy Golang API in test cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,21 @@ jobs:
           name: Initialize cluster
           command: |
             bash -x scripts/init_k8s_cluster.sh
+            NODE=$HOSTNAME bash -x scripts/wait_for_node.sh            
 
       - run:
-          name: Wait for cluster
+          name: Build go-server image
           command: |
-            NODE=$HOSTNAME bash -x scripts/wait_for_node.sh
+            make
+            sudo docker build . -t go-server-img
+
+      - run:
+          name: Deploy go-server in cluster
+          command: |
+            kubectl apply -f deployment.yaml
+            POD=go-server bash -x scripts/wait_for_pod.sh
+
+      - run:
+          name: Integration test(s)
+          command: |
+            curl $HOSTNAME:30007

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-server
+spec:
+  selector:
+    matchLabels:
+      app: go-server
+  template:
+    metadata:
+      labels:
+        app: go-server
+    spec:
+      containers:
+        - name: go-server
+          image: go-server-img
+          imagePullPolicy: Never
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-server
+spec:
+  type: NodePort
+  selector:
+    app: go-server
+  ports:
+    - port: 8080
+      nodePort: 30007

--- a/scripts/init_k8s_cluster.sh
+++ b/scripts/init_k8s_cluster.sh
@@ -63,8 +63,12 @@ mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
-# Being able to deploy PODs on master node
+# Kubectl autocompletion
+echo "source <(kubectl completion bash)" >> ~/.bashrc
+
+# Being able to deploy PODs on master node (won't be master node anymore)
 kubectl taint node $MACHINE_ID node-role.kubernetes.io/control-plane:NoSchedule-
+kubectl taint node $MACHINE_ID node-role.kubernetes.io/master-
 
 # Cluster deployment network
 kubectl create -f https://projectcalico.docs.tigera.io/manifests/tigera-operator.yaml

--- a/scripts/wait_for_pod.sh
+++ b/scripts/wait_for_pod.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# POD=go-server bash -x wait_for_pod.sh
+
+MAX_LOOP=60
+loop=1
+POD=$(kubectl get pod | grep $POD | cut -d' ' -f1)
+
+while [ $loop -le $MAX_LOOP ]
+do
+    # Test Pod's status
+    kubectl wait --for=condition=Ready pod/$POD --timeout=1s >/dev/null
+    if [ $? -eq 0 ]
+    then
+        break
+    fi
+
+    echo "$POD status not ready: $(( $MAX_LOOP - $loop ))"
+    loop=$(( $loop + 1 ))
+done
+
+kubectl wait --for=condition=Ready pod/$POD --timeout=1s


### PR DESCRIPTION
In this PR:
* Update `.circleci/config.yml` by add new run blocks to test the deployment.
* Create a kubernetes deployment use to deploy the golang app in a POD and make it accessible with a service configured as **NodePort**.
* Debug `init_k8s_cluster.sh` script.
* Create `wait_for_pod.sh` script that works as `wait_for_node.sh` but for POD.